### PR TITLE
Fix buffer reading when input buffer is refilled

### DIFF
--- a/laz-perf/io.hpp
+++ b/laz-perf/io.hpp
@@ -422,7 +422,7 @@ namespace laszip {
                 if (request)
                 {
                     fillit_();
-				    std::copy(buf_ + offset, buf_ + offset + request, buf);
+				    std::copy(buf_ + offset, buf_ + offset + request, buf + fetchable);
 				    offset += request;
                 }
 			}


### PR DESCRIPTION
First read bytes were lost when reading bytes second time