### PR TITLE
Clean Python bindings

### DIFF
--- a/python/lazperf/PyLazperf.cpp
+++ b/python/lazperf/PyLazperf.cpp
@@ -51,9 +51,9 @@ LAZEngine::LAZEngine()
 }
 
 
-Decompressor::Decompressor( std::vector<uint8_t>& compressed)
+Decompressor::Decompressor(const unsigned char *data, size_t dataLen)
     : LAZEngine()
-    , m_stream(compressed)
+    , m_stream(data, dataLen)
     , m_decoder(m_stream)
     , m_decompressor(laszip::formats::make_dynamic_decompressor(m_decoder))
 {
@@ -83,7 +83,7 @@ size_t Decompressor::decompress(char* output, size_t buffer_size)
 }
 
 
-Compressor::Compressor( std::vector<uint8_t>& uncompressed)
+Compressor::Compressor(std::vector<uint8_t>& uncompressed)
     : LAZEngine()
     , m_stream(uncompressed)
     , m_encoder(m_stream)
@@ -124,6 +124,11 @@ void Compressor::add_dimension(pylazperf::Type t)
 const std::vector<uint8_t>* Compressor::data() const
 {
     return &m_stream.m_buf;
+}
+
+void Compressor::copy_data_to(uint8_t *destination) const
+{
+    std::copy(m_stream.m_buf.begin(), m_stream.m_buf.end(), destination);
 }
 
 } //Namespace

--- a/python/lazperf/PyLazperf.hpp
+++ b/python/lazperf/PyLazperf.hpp
@@ -44,10 +44,44 @@ public:
         memcpy(b, m_buf.data() + m_idx, len);
         m_idx += len;
     }
-
-    
 };
 
+/*
+ * Provides a read only wrapper around a buffer to allow lazperf's decoders to read from it.
+ * This is used to avoid having to copy uncompressed points data (potentially huge)
+ * from a numpy array to a std::vector
+*/
+class ReadOnlyStream
+{
+public:
+    const uint8_t *m_data;
+    size_t m_dataLength;
+    size_t m_idx;
+
+    ReadOnlyStream(const uint8_t *data, size_t dataLen)
+    : m_data(data)
+    , m_dataLength(dataLen)
+    , m_idx(0)
+    {}
+
+
+    unsigned char getByte()
+    {
+        if (m_idx >= m_dataLength) {
+            throw std::runtime_error("access out of bounds");
+        }
+        return (unsigned char) m_data[m_idx++];
+    }
+
+    void getBytes(unsigned char *b, int len)
+    {
+        if (m_idx + len > m_dataLength) {
+            throw std::runtime_error("access out of bounds");
+        }
+        memcpy(b, (unsigned char*) &m_data[m_idx], len);
+        m_idx += len;
+    }
+};
 
 class LAZEngine
 {
@@ -62,7 +96,7 @@ protected:
 
 class Decompressor : public LAZEngine {
 public:
-    Decompressor(std::vector<uint8_t>&);
+    Decompressor(const uint8_t *data, size_t dataLen);
     ~Decompressor(){};
     void add_dimension(pylazperf::Type t);
     size_t decompress(char* out, size_t buffer_size);
@@ -70,11 +104,11 @@ public:
 
 private:
 
-    typedef laszip::decoders::arithmetic<TypedLazPerfBuf<uint8_t>> Decoder;
+    typedef laszip::decoders::arithmetic<ReadOnlyStream> Decoder;
     typedef typename laszip::formats::dynamic_field_decompressor<Decoder>::ptr
         Engine;
 
-    TypedLazPerfBuf<uint8_t> m_stream;
+    ReadOnlyStream m_stream;
     Decoder m_decoder;
     Engine m_decompressor;
 };
@@ -89,12 +123,12 @@ public:
     void add_dimension(pylazperf::Type t);
     size_t compress(const char* input, size_t buffer_size);
     const std::vector<uint8_t>* data() const;
+    void copy_data_to(uint8_t *destination) const;
 
 private:
 
     typedef laszip::encoders::arithmetic<TypedLazPerfBuf<uint8_t>> Encoder;
-    typedef typename laszip::formats::dynamic_field_compressor<Encoder>::ptr
-            Engine;
+    typedef typename laszip::formats::dynamic_field_compressor<Encoder>::ptr Engine;
 
     TypedLazPerfBuf<uint8_t> m_stream;
     Encoder m_encoder;
@@ -106,10 +140,15 @@ private:
 class VlrDecompressor
 {
 public:
-    VlrDecompressor(std::vector<uint8_t>& data, std::vector<uint8_t>& vlr) :
-        m_stream(data), m_chunksize(0), m_chunkPointsRead(0)
+    VlrDecompressor(
+        const uint8_t *compressedData,
+        size_t dataLength,
+        const char *vlr_data)
+        : m_stream(compressedData, dataLength)
+        , m_chunksize(0)
+        , m_chunkPointsRead(0)
     {
-        laszip::io::laz_vlr zipvlr((const char*)vlr.data());
+        laszip::io::laz_vlr zipvlr(vlr_data);
         m_chunksize = zipvlr.chunk_size;
         m_schema = laszip::io::laz_vlr::to_schema(zipvlr);
     }
@@ -139,9 +178,9 @@ private:
 
     typedef laszip::formats::dynamic_decompressor Decompressor;
     typedef laszip::factory::record_schema Schema;
-    typedef laszip::decoders::arithmetic<TypedLazPerfBuf<uint8_t>> Decoder;
+    typedef laszip::decoders::arithmetic<ReadOnlyStream> Decoder;
 
-    TypedLazPerfBuf<uint8_t> m_stream;
+    ReadOnlyStream m_stream;
 
     std::unique_ptr<Decoder> m_decoder;
     Decompressor::ptr m_decompressor;
@@ -181,6 +220,9 @@ public:
 
     size_t getPointSize() const
         { return (size_t)m_schema.size_in_bytes(); }
+
+    void copy_data_to(uint8_t *dst) const
+        { std::copy(m_data_vec.begin(), m_data_vec.end(), dst); }
 
 
 private:

--- a/python/lazperf/PyLazperf.hpp
+++ b/python/lazperf/PyLazperf.hpp
@@ -111,7 +111,6 @@ public:
     {
         laszip::io::laz_vlr zipvlr((const char*)vlr.data());
         m_chunksize = zipvlr.chunk_size;
-        std::cout << "chunk size: "<< m_chunksize << std::endl;
         m_schema = laszip::io::laz_vlr::to_schema(zipvlr);
     }
 

--- a/python/lazperf/PyLazperf.hpp
+++ b/python/lazperf/PyLazperf.hpp
@@ -157,8 +157,8 @@ typedef laszip::factory::record_schema Schema;
 class VlrCompressor
 {
 public:
-    VlrCompressor(std::vector<uint8_t>&out, Schema s, uint64_t offset_to_data)
-    : m_stream(out)
+    VlrCompressor(Schema s, uint64_t offset_to_data)
+    : m_stream(m_data_vec)
     , m_encoder(nullptr)
     , m_chunkPointsWritten(0)
     , m_offsetToData(offset_to_data)
@@ -176,9 +176,10 @@ public:
 
     size_t vlrDataSize() const
         { return m_vlr.size(); }
+
     void extractVlrData(char *out_data)
         { return m_vlr.extract(out_data); }
-    
+
     size_t getPointSize() const
         { return (size_t)m_schema.size_in_bytes(); }
 
@@ -190,6 +191,7 @@ private:
     void resetCompressor();
     void newChunk();
 
+    std::vector<uint8_t> m_data_vec;
     TypedLazPerfBuf<uint8_t> m_stream;
     std::unique_ptr<Encoder> m_encoder;
     Compressor::ptr m_compressor;

--- a/python/lazperf/PyVlrCompressor.cpp
+++ b/python/lazperf/PyVlrCompressor.cpp
@@ -17,7 +17,7 @@ void VlrCompressor::compress(const char *inbuf)
         // Seek over the chunk info offset value
         unsigned char skip[sizeof(uint64_t)] = {0};
         m_stream.putBytes(skip, sizeof(skip));
-        m_chunkOffset = m_offsetToData + m_chunkInfoPos + sizeof(uint64_t);
+        m_chunkOffset = m_chunkInfoPos + sizeof(uint64_t);
 
         resetCompressor();
     }
@@ -41,10 +41,10 @@ void VlrCompressor::done()
 
     // Save our current position.  Go to the location where we need
     // to write the chunk table offset at the beginning of the point data.
-    
+
     uint64_t chunkTablePos = htole64((uint64_t) m_stream.m_buf.size());
     // We need to add the offset given a construction time since
-    // we did not use a stream to write the headers and vlrs
+    // we did not use a stream to write the header and vlrs
     uint64_t trueChunkTablePos = htole64((uint64_t) m_stream.m_buf.size() +  m_offsetToData);
 
     // Equivalent of stream.seekp(m_chunkInfoPos); stream << chunkTablePos
@@ -58,7 +58,6 @@ void VlrCompressor::done()
     // 2. memcpy the data into the pushed bytes
     unsigned char skip[2 * sizeof(uint32_t)] = {0};
     m_stream.putBytes(skip, sizeof(skip));
-    
     uint32_t version = htole32(0);
     uint32_t chunkTableSize = htole32((uint32_t) m_chunkTable.size());
 
@@ -73,11 +72,11 @@ void VlrCompressor::done()
     compressor.init();
 
     uint32_t predictor = 0;
-    for (uint32_t offset : m_chunkTable)
+    for (uint32_t chunkSize : m_chunkTable)
     {
-        offset = htole32(offset + m_offsetToData);
-        compressor.compress(encoder, predictor, offset, 1);
-        predictor = offset;
+        chunkSize = htole32(chunkSize);
+        compressor.compress(encoder, predictor, chunkSize, 1);
+        predictor = chunkSize;
     }
     encoder.done();
 }

--- a/python/lazperf/__init__.py
+++ b/python/lazperf/__init__.py
@@ -4,6 +4,7 @@ from .pylazperfapi import PyCompressor as Compressor
 from .pylazperfapi import PyVLRDecompressor as VLRDecompressor
 from .pylazperfapi import PyVLRCompressor as VLRCompressor
 from .pylazperfapi import PyRecordSchema as RecordSchema
+from .pylazperfapi import PyLazVlr as LazVLR
 from .pylazperfapi import buildNumpyDescription
 from .pylazperfapi import buildGreyhoundDescription
 

--- a/python/lazperf/lazperf.pxd
+++ b/python/lazperf/lazperf.pxd
@@ -1,0 +1,76 @@
+# distutils: language=c++
+from libcpp.vector cimport vector
+from libc.stdint cimport uint8_t, int32_t, uint64_t
+
+cdef extern from "PyLazperfTypes.hpp" namespace "pylazperf":
+    enum LazPerfType "pylazperf::Type":
+        Double
+        Float
+        Signed8
+        Signed16
+        Signed32
+        Signed64
+        Unsigned8
+        Unsigned16
+        Unsigned32
+        Unsigned64
+
+
+
+cdef extern from "PyLazperf.hpp" namespace "pylazperf":
+    cdef cppclass Decompressor:
+        Decompressor(const uint8_t *data, size_t dataLen) except +
+        size_t decompress(char* buffer, size_t length)  except +
+        size_t getPointSize()
+        void add_dimension(LazPerfType t)
+
+
+
+cdef extern from "PyLazperf.hpp" namespace "pylazperf":
+    cdef cppclass Compressor:
+        Compressor(vector[uint8_t]& arr) except +
+        size_t compress(const char* buffer, size_t length)  except +
+        size_t getPointSize()
+        void add_dimension(LazPerfType t)
+        void done()
+        const vector[uint8_t]* data()
+        void copy_data_to(uint8_t *dest) const
+
+
+cdef extern from "laz-perf/factory.hpp" namespace "laszip::factory::record_item":
+    cdef enum record_item "laszip::factory::record_item":
+        POINT10,
+        GPSTIME,
+        RGB12
+
+cdef extern from "laz-perf/factory.hpp" namespace "laszip::factory":
+    cdef cppclass record_schema:
+        record_schema()
+        void push(record_item)
+
+
+cdef extern from 'laz-perf/io.hpp' namespace "laszip::io":
+    cdef cppclass laz_vlr:
+        laz_vlr()
+        void extract(char *data)
+        size_t size() const
+        @staticmethod
+        laz_vlr from_schema(const record_schema)
+
+cdef extern from "PyLazperf.hpp" namespace "pylazperf":
+    cdef cppclass VlrDecompressor:
+        VlrDecompressor(const unsigned char* compressed_data, size_t dataLength, const char *vlr) except +
+        size_t decompress(char* buffer)  except +
+        size_t getPointSize()
+
+
+cdef extern from "PyLazperf.hpp" namespace "pylazperf":
+    cdef cppclass VlrCompressor:
+        VlrCompressor(record_schema, uint64_t offset) except +
+        size_t compress(const char *inbuf) except +
+        void done()
+        const vector[uint8_t]* data()
+        size_t getPointSize()
+        size_t vlrDataSize() const
+        void extractVlrData(char* out)
+        void copy_data_to(uint8_t *dst) const

--- a/python/lazperf/pylazperfapi.pyx
+++ b/python/lazperf/pylazperfapi.pyx
@@ -135,7 +135,7 @@ cdef extern from "laz-perf/factory.hpp" namespace "laszip::factory":
 
 cdef extern from "PyLazperf.hpp" namespace "pylazperf":
     cdef cppclass VlrCompressor:
-        VlrCompressor(vector[uint8_t]& out, record_schema, uint64_t offset) except +
+        VlrCompressor(record_schema, uint64_t offset) except +
         size_t compress(const char *inbuf) except +
         void done()
         const vector[uint8_t]* data()
@@ -328,13 +328,7 @@ cdef class PyVLRCompressor:
     cdef VlrCompressor *thisptr;
 
     def __cinit__(self, PyRecordSchema py_record_schema, uint64_t offset):
-        cdef char *x
-        cdef uint8_t buf
-        cdef vector[uint8_t]* v
-
-        v = new vector[uint8_t]()
-
-        self.thisptr = new VlrCompressor(v[0], py_record_schema.schema, offset)
+        self.thisptr = new VlrCompressor(py_record_schema.schema, offset)
 
     def get_vlr_data(self):
         cdef size_t vlr_size = self.thisptr.vlrDataSize()
@@ -371,7 +365,3 @@ cdef class PyVLRCompressor:
     def __dealloc__(self):
         del self.thisptr
 
-
-
-
-    

--- a/python/lazperf/pylazperfapi.pyx
+++ b/python/lazperf/pylazperfapi.pyx
@@ -1,14 +1,17 @@
-# distutils: language = c++ 
+# distutils: language = c++
 
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libc.stdint cimport uint8_t, int32_t, uint64_t
+from libc.string cimport memcpy
 from cpython.version cimport PY_MAJOR_VERSION
-cimport numpy as np
-import numpy as np
-np.import_array()
 from cpython.array cimport array, clone
+
 import json as jsonlib
+import numpy as np
+
+cimport numpy as np
+np.import_array()
 
 def get_lazperf_type(size, t):
     if t == 'floating':
@@ -101,14 +104,14 @@ cdef extern from "PyLazperfTypes.hpp" namespace "pylazperf":
 
 cdef extern from "PyLazperf.hpp" namespace "pylazperf":
     cdef cppclass Decompressor:
-        Decompressor(vector[uint8_t]& arr) except +
+        Decompressor(const uint8_t *data, size_t dataLen) except +
         size_t decompress(char* buffer, size_t length)  except +
         size_t getPointSize()
         void add_dimension(LazPerfType t)
 
 cdef extern from "PyLazperf.hpp" namespace "pylazperf":
     cdef cppclass VlrDecompressor:
-        VlrDecompressor(vector[uint8_t]& data, vector[uint8_t]& vlr) except +
+        VlrDecompressor(const unsigned char* compressed_data, size_t dataLength, const char *vlr) except +
         size_t decompress(char* buffer)  except +
         size_t getPointSize()
 
@@ -121,6 +124,7 @@ cdef extern from "PyLazperf.hpp" namespace "pylazperf":
         void add_dimension(LazPerfType t)
         void done()
         const vector[uint8_t]* data()
+        void copy_data_to(uint8_t *dest) const
 
 cdef extern from "laz-perf/factory.hpp" namespace "laszip::factory::record_item":
     cdef enum record_item "laszip::factory::record_item":
@@ -142,6 +146,7 @@ cdef extern from "PyLazperf.hpp" namespace "pylazperf":
         size_t getPointSize()
         size_t vlrDataSize() const
         void extractVlrData(char* out)
+        void copy_data_to(uint8_t *dst) const
 
 cdef extern from 'laz-perf/io.hpp' namespace "laszip::io":
     cdef cppclass laz_vlr:
@@ -153,6 +158,10 @@ cdef extern from 'laz-perf/io.hpp' namespace "laszip::io":
 
 
 cdef class PyRecordSchema:
+    """ This class is used to represent a LAS record schema
+    This RecordSchema is nessecary for the LazVlr to be able to compress
+    points meant to be written in a LAZ file.
+    """
     cdef record_schema schema
 
     def __cinit__(self):
@@ -165,6 +174,10 @@ cdef class PyRecordSchema:
         self.schema.push(RGB12)
 
 cdef class PyLazVlr:
+    """ Wraps a Lazperf's LazVlr class.
+    This class is meant to give access to the Laszip's vlr raw record_data
+    to allow writers to write LAZ files with its corresponding laszip vlr.
+    """
     cdef laz_vlr vlr
     cdef public PyRecordSchema schema
 
@@ -173,6 +186,9 @@ cdef class PyLazVlr:
         self.vlr = laz_vlr.from_schema(schema.schema)
 
     def data(self):
+        """ returns the laszip vlr record_data as a numpy array of bytes
+        to be written in the VLR section of a LAZ compressed file.
+        """
         cdef size_t vlr_size = self.vlr.size()
         cdef np.ndarray[uint8_t, ndim=1, mode="c"] arr = np.ndarray(vlr_size, dtype=np.uint8)
 
@@ -180,39 +196,36 @@ cdef class PyLazVlr:
         return arr
 
     def data_size(self):
+        """ Returns the number of bytes in the lazvlr record_data
+        """
         return self.vlr.size()
 
 
 
 cdef class PyCompressor:
+    """ Class to compress points in the laz format using a json schema or numpy dtype
+    to describe the point format
+    """
     cdef Compressor *thisptr      # hold a c++ instance which we're wrapping
     cdef public str jsondata
     cdef vector[uint8_t] *v
 
-    def add_dimensions(self, jsondata):
+    def __cinit__(self, object schema):
+        """
+        schema: numpy dtype or json string of the point schema
+        """
+        self.v = new vector[uint8_t]()
+        self.thisptr = new Compressor(self.v[0])
 
-        data = None
         try:
-            jsondata[0]['type']
-            data = jsondata
-        except:
-            data = jsonlib.loads(jsondata)
-
-        for dim in data:
-            t = get_lazperf_type(dim['size'], dim['type'])
-            self.thisptr.add_dimension(t)
-
-    cdef get_data(self):
-        cdef const vector[uint8_t]* v = self.thisptr.data()
-        cdef size_t size = v.size()
-        cdef np.ndarray[uint8_t, ndim=1, mode="c"] arr = np.ndarray(size, dtype=np.uint8)
-        cdef size_t i = 0
-
-        for i in range(size):
-            arr[i] = self.v[0][i]
-        return arr
+            self.jsondata = jsonlib.dumps(buildGreyhoundDescription(schema))
+        except AttributeError:
+            self.jsondata = schema
+        self.add_dimensions(self.jsondata)
 
     def compress(self, np.ndarray arr not None):
+        """ Compresses points and return the result as a numpy array of bytes
+        """
 
         cdef np.ndarray[uint8_t, ndim=1, mode="c"] view
         view = arr.view(dtype=np.uint8)
@@ -221,34 +234,15 @@ cdef class PyCompressor:
         self.done()
         return self.get_data()
 
+    cdef get_data(self):
+        cdef const vector[uint8_t]* v = self.thisptr.data()
+        cdef np.ndarray[uint8_t, ndim=1, mode="c"] arr = np.zeros(v.size(), dtype=np.uint8)
+
+        self.thisptr.copy_data_to(<uint8_t*> arr.data)
+        return arr
 
     def done(self):
         self.thisptr.done()
-
-    def _init(self):
-        self.add_dimensions(self.jsondata)
-
-    def __cinit__(self, object schema):
-        cdef uint8_t* buf
-
-        self.v = new vector[uint8_t]()
-
-        self.thisptr = new Compressor(self.v[0])
-        try:
-            self.jsondata = jsonlib.dumps(buildGreyhoundDescription(schema))
-        except AttributeError:
-            self.jsondata = schema
-        self._init()
-
-    def __dealloc__(self):
-        del self.v
-        del self.thisptr
-
-
-cdef class PyDecompressor:
-    cdef Decompressor *thisptr      # hold a c++ instance which we're wrapping
-    cdef vector[uint8_t] *v
-    cdef public str jsondata
 
     def add_dimensions(self, jsondata):
 
@@ -263,100 +257,124 @@ cdef class PyDecompressor:
             t = get_lazperf_type(dim['size'], dim['type'])
             self.thisptr.add_dimension(t)
 
+    def __dealloc__(self):
+        del self.v
+        del self.thisptr
+
+
+cdef class PyDecompressor:
+    """ Class to decompress laz points using a json schema/numpy dtype to
+    describe the point format
+    """
+    cdef Decompressor *thisptr      # hold a c++ instance which we're wrapping
+    cdef public str jsondata
+
+    def __cinit__(self, np.ndarray[uint8_t, ndim=1, mode="c"] compressed_points not None, object schema):
+        """
+        compressed_points: buffer of compressed_points
+        schema: numpy dtype or json string of the point schema
+        """
+        try:
+            self.jsondata = jsonlib.dumps(buildGreyhoundDescription(schema))
+        except AttributeError:
+            self.jsondata = schema
+
+        self.thisptr = new Decompressor(<const uint8_t*>compressed_points.data, compressed_points.shape[0])
+        self.add_dimensions(self.jsondata)
 
     def decompress(self, size_t num_points):
+        """ decompress points
+
+        returns the numpy structured array of the decompressed points
+        """
         cdef size_t point_size = self.thisptr.getPointSize()
         cdef np.ndarray[uint8_t, ndim=1, mode="c"] out = np.zeros(num_points * point_size, np.uint8)
 
         point_count = self.thisptr.decompress(out.data, out.shape[0])
         return out.view(dtype=buildNumpyDescription(self.jsondata))
 
-    def _init(self):
-        self.add_dimensions(self.jsondata)
-
-    def __cinit__(self, np.ndarray[uint8_t, ndim=1, mode="c"]  data not None, object schema):
-        cdef uint8_t* buf
-
-        buf = <uint8_t*> data.data;
-        self.v = new vector[uint8_t]()
-        self.v.assign(buf, buf + len(data))
-
+    def add_dimensions(self, jsondata):
+        data = None
         try:
-            self.jsondata = jsonlib.dumps(buildGreyhoundDescription(schema))
-        except AttributeError:
-            self.jsondata = schema
+            jsondata[0]['type']
+            data = jsondata
+        except:
+            data = jsonlib.loads(jsondata)
 
-        self.thisptr = new Decompressor(self.v[0])
-        self._init()
+        for dim in data:
+            t = get_lazperf_type(dim['size'], dim['type'])
+            self.thisptr.add_dimension(t)
+
 
     def __dealloc__(self):
-        del self.v
         del self.thisptr
 
 
 cdef class PyVLRDecompressor:
+    """ Class to decompress laz points stored in a .laz file using the
+    Laszip vlr's record_data
+    """
     cdef VlrDecompressor *thisptr      # hold a c++ instance which we're wrapping
-    cdef vector[uint8_t] *data_v;
-    cdef vector[uint8_t] *vlr_v;
+
+    def __cinit__(
+            self,
+            np.ndarray[uint8_t, ndim=1, mode="c"] compressed_points not None,
+            np.ndarray[uint8_t, ndim=1, mode="c"] vlr not None
+        ):
+        """
+        compressed_points: buffer of points to be decompressed
+        vlr: laszip vlr's record_data as an array of bytes
+        """
+        cdef const uint8_t *p_compressed =  <const uint8_t*> compressed_points.data
+        self.thisptr = new VlrDecompressor(p_compressed, compressed_points.shape[0], vlr.data)
 
     def decompress_points(self, size_t point_count):
+        """ decompress the points
+
+        returns the decompressed data as an array of bytes
+        """
         cdef size_t point_size = self.thisptr.getPointSize()
-        cdef np.ndarray[uint8_t, ndim=1, mode="c"] data = np.zeros(point_size, dtype=np.uint8)
-        cdef np.ndarray[uint8_t, ndim=1, mode="c"] point_uncompressed = np.zeros(point_count * point_size, dtype=np.uint8)
+        cdef np.ndarray[uint8_t, ndim=1, mode="c"] point_out = np.zeros(point_size, dtype=np.uint8)
+        cdef np.ndarray[uint8_t, ndim=1, mode="c"] points_uncompressed = np.zeros(point_count * point_size, dtype=np.uint8)
         cdef size_t i = 0
         cdef size_t begin = 0
         cdef size_t end = 0
 
         # Cython's memory views are needed to get the true C speed when slicing
-        cdef uint8_t [:] point_view  = point_uncompressed
-        cdef uint8_t [:] data_view = data
+        cdef uint8_t [:] points_view  = points_uncompressed
+        cdef uint8_t [:] out_view = point_out
 
         for _ in range(point_count):
-            self.thisptr.decompress(data.data)
+            self.thisptr.decompress(point_out.data)
             end = begin + point_size
-            point_view[begin:end] = data_view
+            points_view[begin:end] = out_view
             begin = end
-      
-        return point_uncompressed
 
-
-    def __cinit__(self, np.ndarray[uint8_t, ndim=1, mode="c"]  data not None,
-                        np.ndarray[uint8_t, ndim=1, mode="c"]  vlr not None):
-        cdef uint8_t* data_buf
-        cdef uint8_t* vlr_buf
-
-        data_buf = <uint8_t*> data.data;
-        self.data_v = new vector[uint8_t]()
-        self.data_v.assign(data_buf, data_buf + len(data))
-
-        vlr_buf = <uint8_t*> vlr.data;
-        self.vlr_v = new vector[uint8_t]()
-        self.vlr_v.assign(vlr_buf, vlr_buf + len(vlr))
-
-        self.thisptr = new VlrDecompressor(self.data_v[0], self.vlr_v[0])
+        return points_uncompressed
 
     def __dealloc__(self):
-        del self.vlr_v
-        del self.data_v
         del self.thisptr
 
 cdef class PyVLRCompressor:
+    """ Class to compress las points into laz format with the record schema
+    from a laszip vlr, this is meant to be used by LAZ file writers
+    """
     cdef VlrCompressor *thisptr;
 
     def __cinit__(self, PyRecordSchema py_record_schema, uint64_t offset):
+        """
+        py_record_schema: The schema of the point format
+        offset: offset to the point data (same as the las header field).
+        This is needed because the first 8 bytes of the compressed points is an offset to the
+        chunk table relative to the start of Las file. (Or you could pass in offset=0 and modify the
+        8 bytes yourself)
+        """
         self.thisptr = new VlrCompressor(py_record_schema.schema, offset)
 
-    def get_data(self):
-        cdef const vector[uint8_t]* v = self.thisptr.data()
-        cdef size_t size = v.size()
-        cdef np.ndarray[uint8_t, ndim=1, mode="c"] arr = np.ndarray(size, dtype=np.uint8)
-        cdef size_t i = 0
-
-        for i in range(size):
-            arr[i] = v[0][i]
-        return arr
 
     def compress(self, np.ndarray arr):
+        """ Returns the compressed points as a numpy array of bytes
+        """
         cdef np.ndarray[char, ndim=1, mode="c"] view
         view = arr.view(np.uint8)
 
@@ -377,6 +395,11 @@ cdef class PyVLRCompressor:
         self.thisptr.done()
         return self.get_data()
 
+    def get_data(self):
+        cdef const vector[uint8_t]* v = self.thisptr.data()
+        cdef np.ndarray[uint8_t, ndim=1, mode="c"] arr = np.ndarray(v.size(), dtype=np.uint8)
+        self.thisptr.copy_data_to(<uint8_t*>arr.data)
+        return arr
 
     def __dealloc__(self):
         del self.thisptr

--- a/python/lazperf/pylazperfapi.pyx
+++ b/python/lazperf/pylazperfapi.pyx
@@ -228,7 +228,6 @@ cdef class PyCompressor:
         self.add_dimensions(self.jsondata)
 
     def __cinit__(self, object schema):
-        cdef char* x
         cdef uint8_t* buf
         cdef vector[uint8_t]* v
 
@@ -263,20 +262,17 @@ cdef class PyDecompressor:
             self.thisptr.add_dimension(t)
 
 
-    def decompress(self, np.ndarray data):
-        cdef np.ndarray[uint8_t, ndim=1, mode="c"] view
+    def decompress(self, size_t num_points):
+        cdef size_t point_size = self.thisptr.getPointSize()
+        cdef np.ndarray[uint8_t, ndim=1, mode="c"] out = np.zeros(num_points * point_size, np.uint8)
 
-        view = data.view(dtype=np.uint8)
-        point_count = self.thisptr.decompress(view.data, view.shape[0])
-        output = np.resize(view, self.thisptr.getPointSize() * point_count)
-        view2 = output.view(dtype=buildNumpyDescription(self.jsondata))
-        return view2
+        point_count = self.thisptr.decompress(out.data, out.shape[0])
+        return out.view(dtype=buildNumpyDescription(self.jsondata))
 
     def _init(self):
         self.add_dimensions(self.jsondata)
 
     def __cinit__(self, np.ndarray[uint8_t, ndim=1, mode="c"]  data not None, object schema):
-        cdef char* x
         cdef uint8_t* buf
         cdef vector[uint8_t]* v
 

--- a/python/lazperf/pylazperfapi.pyx
+++ b/python/lazperf/pylazperfapi.pyx
@@ -373,12 +373,18 @@ cdef class PyVLRCompressor:
             arr[i] = v[0][i]
         return arr
 
-    def compress(self, np.ndarray arr, size_t point_count):
+    def compress(self, np.ndarray arr):
         cdef np.ndarray[char, ndim=1, mode="c"] view
         view = arr.view(np.uint8)
 
         cdef char *ptr = arr.data
         cdef size_t point_size = self.thisptr.getPointSize()
+        cdef size_t num_bytes = arr.shape[0]
+        cdef size_t point_count = num_bytes / point_size
+
+        if arr.shape[0] % point_size != 0:
+            raise ValueError("The number of bytes ({}) is not divisible by the point size ({})"
+            " it gives {} points".format(num_bytes, point_size, <float>num_bytes / point_size))
 
         for i in range(point_count):
             self.thisptr.compress(ptr)

--- a/python/setup.py
+++ b/python/setup.py
@@ -83,7 +83,8 @@ extensions = [DistutilsExtension("lazperf.pylazperfapi",
                                    include_dirs=include_dirs,
                                    library_dirs=library_dirs,
                                    extra_compile_args=extra_compile_args,
-                                   extra_link_args=extra_link_args,)]
+                                   extra_link_args=extra_link_args,
+                                   language="c++",)]
 if USE_CYTHON and "clean" not in sys.argv:
     from Cython.Build import cythonize
     extensions= cythonize(extensions, language="c++")

--- a/python/test/test_lazperf.py
+++ b/python/test/test_lazperf.py
@@ -50,7 +50,7 @@ class TestLazPerf(unittest.TestCase):
         self.assertEqual(uncompressed.shape[0], expected_point_count)
         self.assertEqual(decompressed.shape[0], expected_point_count)
         for i in range(len(uncompressed)):
-            self.assertEqual(uncompressed[i], decompressed[i])
+           self.assertEqual(uncompressed[i], decompressed[i])
 
     def test_compressor(self):
         s = json.dumps(schema)
@@ -90,8 +90,8 @@ class TestLazPerf(unittest.TestCase):
         c = Compressor(s)
 
         compressed = c.compress(point_data)
-
         original_compressed = np.frombuffer(data[0:-4], dtype = np.uint8)
+
         self.assertEqual(len(original_compressed), len_compressed - 4)
         for i in range(len(compressed)):
             self.assertEqual(compressed[i], original_compressed[i])

--- a/python/test/test_lazperf.py
+++ b/python/test/test_lazperf.py
@@ -44,8 +44,7 @@ class TestLazPerf(unittest.TestCase):
         self.assertEqual(dtype.itemsize, 54)
 
         d = Decompressor(arr, s)
-        output = np.zeros(compressed_point_count * dtype.itemsize, dtype=np.uint8)
-        decompressed = d.decompress(output)
+        decompressed = d.decompress(compressed_point_count)
         uncompressed = np.frombuffer(original[0:-4], dtype = dtype)
 
         self.assertEqual(uncompressed.shape[0], expected_point_count)
@@ -110,8 +109,7 @@ class TestLazPerf(unittest.TestCase):
         compressed = c.compress(uncompressed)
 
         d = Decompressor(compressed, s)
-        output = np.zeros(expected_point_count * dtype.itemsize, dtype = np.uint8)
-        decompressed = d.decompress(output)
+        decompressed = d.decompress(expected_point_count)
         self.assertEqual(len(decompressed), len(uncompressed))
         for i in range(len(decompressed)):
             self.assertEqual(decompressed[i], uncompressed[i])

--- a/python/test/test_lazperf_vlr.py
+++ b/python/test/test_lazperf_vlr.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import struct
 from lazperf import VLRDecompressor, VLRCompressor, RecordSchema, LazVLR
 
 
@@ -8,7 +9,8 @@ las_header_size = 227
 vlr_header_size = 54
 offset_to_laszip_vlr_data = las_header_size + vlr_header_size
 laszip_vlr_data_size = 52
-offset_to_point_data = offset_to_laszip_vlr_data + laszip_vlr_data_size + 8
+gt_offset_to_point_data = offset_to_laszip_vlr_data + laszip_vlr_data_size
+sizeof_chunk_table_offset = 8
 point_count = 1065
 
 point_dtype = np.dtype([('X', '<i4'), ('Y', '<i4'), ('Z', '<i4'), ('intensity', '<u2'), ('bit_fields', 'u1'), ('raw_classification', 'u1'), ('scan_angle_rank', 'i1'), ('user_data', 'u1'), ('point_source_id', '<u2'), ('gps_time', '<f8'), ('red', '<u2'), ('green', '<u2'), ('blue', '<u2')])
@@ -27,7 +29,7 @@ class TestVLRDecompress(unittest.TestCase):
         laszip_vlr_data = raw_data[
             offset_to_laszip_vlr_data: offset_to_laszip_vlr_data + laszip_vlr_data_size ]
 
-        raw_points = raw_data[offset_to_point_data:]
+        raw_points = raw_data[gt_offset_to_point_data + sizeof_chunk_table_offset:]
 
         laszip_vlr_data = np.frombuffer(laszip_vlr_data, dtype=np.uint8)
         compressed_points = np.frombuffer(raw_points, dtype=np.uint8)
@@ -53,8 +55,7 @@ class TestVLRCompress(unittest.TestCase):
             offset_to_laszip_vlr_data: offset_to_laszip_vlr_data + laszip_vlr_data_size ]
 
         gt_vlr_data = np.frombuffer(laszip_vlr_data, dtype=np.uint8)
-        gt_point_compressed = np.frombuffer(ground_truth[offset_to_point_data:], dtype=np.uint8)
-
+        gt_points_compressed = np.frombuffer(ground_truth[gt_offset_to_point_data + sizeof_chunk_table_offset:], dtype=np.uint8)
 
         rs = RecordSchema()
         rs.add_gps_time()
@@ -66,18 +67,25 @@ class TestVLRCompress(unittest.TestCase):
         self.assertEqual(vlr.data_size(), laszip_vlr_data_size)
         self.assertTrue(np.all(vlr_data == gt_vlr_data))
 
-        compressor = VLRCompressor(rs, offset_to_laszip_vlr_data + vlr.data_size())
-        compressed = compressor.compress(points_to_compress)
+        offset_to_data = offset_to_laszip_vlr_data + vlr.data_size()
+        self.assertEqual(offset_to_data, gt_offset_to_point_data)
 
-        chunk_table_offset = compressed[:8].tobytes()
-        chunk_table = compressed[:-8].tobytes()
-        points_compressed = compressed[8:].tobytes()
+        compressor = VLRCompressor(rs, offset_to_data)
+        points_compressed = compressor.compress(points_to_compress)
 
-        gt_chunk_table_offset = ground_truth[offset_to_point_data - 8:offset_to_point_data]
-        gt_chunk_table = ground_truth[offset_to_point_data:-8]
-        gt_points_compressed = ground_truth[offset_to_point_data:]
-
+        chunk_table_offset = struct.unpack('<Q', points_compressed[:sizeof_chunk_table_offset].tobytes())[0]
+        gt_chunk_table_offset = struct.unpack('<Q', ground_truth[gt_offset_to_point_data:gt_offset_to_point_data + sizeof_chunk_table_offset])[0]
         self.assertEqual(chunk_table_offset, gt_chunk_table_offset)
+
+        # This is the chunkt table offset relative to the point data
+        # without las header and vlrs
+        relative_chunk_table_offset = chunk_table_offset - offset_to_data
+        chunk_table = points_compressed[relative_chunk_table_offset:].tobytes()
+        gt_chunk_table = ground_truth[gt_chunk_table_offset:]
+        self.assertEqual(chunk_table, gt_chunk_table)
+
+        points_compressed = points_compressed[sizeof_chunk_table_offset:].tobytes()
+        gt_points_compressed = ground_truth[gt_offset_to_point_data + sizeof_chunk_table_offset:]
         self.assertEqual(points_compressed, gt_points_compressed)
 
 

--- a/python/test/test_lazperf_vlr.py
+++ b/python/test/test_lazperf_vlr.py
@@ -78,7 +78,7 @@ class TestVLRCompress(unittest.TestCase):
         gt_chunk_table_offset = struct.unpack('<Q', ground_truth[gt_offset_to_point_data:gt_offset_to_point_data + sizeof_chunk_table_offset])[0]
         self.assertEqual(chunk_table_offset, gt_chunk_table_offset)
 
-        # This is the chunkt table offset relative to the point data
+        # This is the chunk table offset relative to the point data
         # without las header and vlrs
         relative_chunk_table_offset = chunk_table_offset - offset_to_data
         chunk_table = points_compressed[relative_chunk_table_offset:].tobytes()

--- a/python/test/test_lazperf_vlr.py
+++ b/python/test/test_lazperf_vlr.py
@@ -34,7 +34,7 @@ class TestVLRDecompress(unittest.TestCase):
 
         decompressor = VLRDecompressor(compressed_points, laszip_vlr_data)
         points_decompressed = decompressor.decompress_points(point_count)
-        
+
         points_decompressed = np.frombuffer(points_decompressed, dtype=point_dtype)
         points_groud_truth = np.frombuffer(groud_truth, dtype=point_dtype)
 
@@ -63,11 +63,11 @@ class TestVLRCompress(unittest.TestCase):
         vlr = LazVLR(rs)
         vlr_data = vlr.data()
 
-        self.assertTrue(np.all(vlr_data == gt_vlr_data))
         self.assertEqual(vlr.data_size(), laszip_vlr_data_size)
+        self.assertTrue(np.all(vlr_data == gt_vlr_data))
 
         compressor = VLRCompressor(rs, offset_to_laszip_vlr_data + vlr.data_size())
-        compressed = compressor.compress(points_to_compress, point_count)
+        compressed = compressor.compress(points_to_compress)
 
         chunk_table_offset = compressed[:8].tobytes()
         chunk_table = compressed[:-8].tobytes()
@@ -83,6 +83,3 @@ class TestVLRCompress(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-        
-
-        

--- a/python/test/test_lazperf_vlr.py
+++ b/python/test/test_lazperf_vlr.py
@@ -44,6 +44,7 @@ class TestVLRDecompress(unittest.TestCase):
 
 class TestVLRCompress(unittest.TestCase):
 
+
     def test_compression(self):
         with open('test/simple_points_uncompressed.bin', mode='rb') as fin:
             points_to_compress = np.frombuffer(fin.read(), dtype=np.uint8)
@@ -88,6 +89,24 @@ class TestVLRCompress(unittest.TestCase):
         gt_points_compressed = ground_truth[gt_offset_to_point_data + sizeof_chunk_table_offset:]
         self.assertEqual(points_compressed, gt_points_compressed)
 
+    def test_raises(self):
+        with open('test/simple_points_uncompressed.bin', mode='rb') as fin:
+            point_buffer = fin.read()
+
+        rs = RecordSchema()
+        rs.add_gps_time()
+        rs.add_rgb()
+
+        vlr = LazVLR(rs)
+        vlr_data = vlr.data()
+
+        # Cut off point data to check if exception is properly raised
+        points_to_compress = np.frombuffer(point_buffer[:-12], dtype=np.uint8)
+        offset_to_data = offset_to_laszip_vlr_data + vlr.data_size()
+        compressor = VLRCompressor(rs, offset_to_data)
+
+        with self.assertRaises(ValueError):
+            points_compressed = compressor.compress(points_to_compress)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Fixes writing of chunktable in the PyVLRCompressor
- Adds LazVLR bindings 
- Fixes a few leaks due to undeleted vectors
- Adds a class to fake a read-only stream to avoir copying (potentially huge) uncompressed points data from a numpy array to a std::vector in the Compressors classes
- Splits cpp declarations in a .pxd file, and Cython code in .pyx
- Adds docstrings