### PR TITLE
Add emscripten build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,26 @@
 # .travis.yml
 #
+matrix:
+    include:
+        - language: cpp
+          compiler:
+              - g++
+          branches:
+              except:
+                  - debian/precise
+          before_install: ./scripts/ci/pre.sh
+          script: ./scripts/ci/run.sh
 
-language: cpp
+    include:
+        - language: node_js
+          node_js:
+              - node
+          sudo: required
 
-compiler:
-    - g++
+          services:
+              - docker
+          before_install:
+              - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
 
-branches:
-    except:
-        - debian/precise
-
-before_install: ./scripts/ci/pre.sh
-
-script: ./scripts/ci/run.sh
+          script:
+            - docker exec -it emscripten ./emscripten-build.sh


### PR DESCRIPTION
I think it makes sense to have an emscripten build also in the ci (especially when changes are made to files like portable endian #47  ).