### PR TITLE
Fix point10 intensity decompression

### DIFF
--- a/laz-perf/detail/field_point10.hpp
+++ b/laz-perf/detail/field_point10.hpp
@@ -268,6 +268,7 @@ namespace laszip {
                     common_.last_ = packers<las::point10>::unpack(buf);
 					// we are done here
 
+					common_.last_.intensity = 0;
 					return buf + sizeof(las::point10);
 				}
 

--- a/python/lazperf/PyVlrCompressor.cpp
+++ b/python/lazperf/PyVlrCompressor.cpp
@@ -34,8 +34,10 @@ void VlrCompressor::compress(const char *inbuf)
 void VlrCompressor::done()
 {
     // Close and clear the point encoder.
-    m_encoder->done();
-    m_encoder.reset();
+    if (m_encoder) {
+        m_encoder->done();
+        m_encoder.reset();
+    }
 
     newChunk();
 

--- a/test/lazperf_tests.cpp
+++ b/test/lazperf_tests.cpp
@@ -1573,3 +1573,40 @@ TEST(lazperf_tests, dynamic_can_do_blind_compression) {
         }
     }
 }
+
+TEST(lazperf_tests, point_10_intensity) {
+	using namespace laszip;
+	using namespace laszip::formats;
+
+	SuchStream s;
+	encoders::arithmetic <SuchStream> encoder(s);
+
+	record_compressor<field<las::point10>> comp;
+
+	std::array<las::point10, 7> points;
+	points[0].intensity = 257;
+	points[1].intensity = 0;
+	points[2].intensity = 0;
+	points[3].intensity = 0;
+	points[4].intensity = 257;
+	points[5].intensity = 257;
+	points[6].intensity = 514;
+
+	for (const las::point10& point : points)
+	{
+		comp.compressWith(encoder, (char*)&point);
+	}
+	encoder.done();
+
+
+	decoders::arithmetic<SuchStream> decoder(s);
+
+	record_decompressor<field<las::point10>> decomp;
+
+	las::point10 decompressedPoint;
+	for (const las::point10 &point : points)
+	{
+		decomp.decompressWith(decoder, (char *)&decompressedPoint);
+		EXPECT_EQ(point.intensity, decompressedPoint.intensity);
+	}
+}


### PR DESCRIPTION
A set of the las point intensity to 0 was missing when reading the first point

https://github.com/LASzip/LASzip/blob/f1c295c0b3f970f0dc637f625985cad53c7dcbf1/src/lasreaditemcompressed_v2.cpp#L130