### PR TITLE
Fix null deref and support for streams that can't seek past end

### DIFF
--- a/cpp/lazperf/readers.cpp
+++ b/cpp/lazperf/readers.cpp
@@ -126,6 +126,10 @@ void basic_file::Private::readPoint(char *out)
             chunk_point_num = 0;
         }
 
+        if (!pdecompressor) {
+            throw std::invalid_argument("No decompressor for point format");
+        }
+
         pdecompressor->decompress(out);
         chunk_point_num++;
     }

--- a/cpp/lazperf/writers.cpp
+++ b/cpp/lazperf/writers.cpp
@@ -172,6 +172,10 @@ void basic_file::Private::writePoint(const char *p)
         else if ((chunk_point_num == chunk_size) && (chunk_size != VariableChunkSize))
             newChunk();
 
+        if (!pcompressor) {
+            throw std::invalid_argument("No compressor for point format");
+        }
+
         // now write the point
         pcompressor->compress(p);
         chunk_point_num++;

--- a/cpp/lazperf/writers.cpp
+++ b/cpp/lazperf/writers.cpp
@@ -111,8 +111,9 @@ bool basic_file::Private::open(std::ostream& out, const header12& h, uint32_t cs
 
     if (compressed())
     {
-        // Seek past the chunk table offset.
-        out.seekp(sizeof(uint64_t), std::ios_base::cur);
+        // Save space for the chunk table offset
+        uint64_t chunk_table_offset = 0;
+        out.write((const char *)&chunk_table_offset, sizeof(uint64_t));
     }
     stream.reset(new OutFileStream(out));
     return true;


### PR DESCRIPTION
It's always better to throw an exception instead of crash. 
Also I use a `boost::interprocess::basic_vectorstream` to store the data, which doesn't support seeking past the end.