### PR TITLE
portable_endian.hpp: Use sys/endian.h on NetBSD

### DIFF
--- a/cpp/lazperf/portable_endian.hpp
+++ b/cpp/lazperf/portable_endian.hpp
@@ -43,11 +43,11 @@
 #   define __PDP_ENDIAN    PDP_ENDIAN
 **/
 
-#elif defined(__OpenBSD__)|| defined(__FreeBSD__) 
+#elif defined(__OpenBSD__)|| defined(__FreeBSD__) || defined(__NetBSD__)
 
 #   include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__DragonFly__)
+#elif defined(__DragonFly__)
 
 #   define be16toh betoh16
 #   define le16toh letoh16


### PR DESCRIPTION
NetBSD has had sys/endian.h for a very long time, so just use it as is
done on FreeBSD and OpenBSD.

With the code before this change, there are errors about redefining symbols and invalid symbols.