### PR TITLE
fix warning on bitwise operator with boolean operands

### DIFF
--- a/cpp/lazperf/detail/field_rgb10.cpp
+++ b/cpp/lazperf/detail/field_rgb10.cpp
@@ -47,9 +47,9 @@ unsigned int color_diff_bits(const las::rgb& this_val, const las::rgb& last)
                     (__flag_diff(a.g, b.g, 0xFF00) << 3) |
                     (__flag_diff(a.b, b.b, 0x00FF) << 4) |
                     (__flag_diff(a.b, b.b, 0xFF00) << 5) |
-                    (__flag_diff(b.r, b.g, 0x00FF) |
-                     __flag_diff(b.r, b.b, 0x00FF) |
-                     __flag_diff(b.r, b.g, 0xFF00) |
+                    (__flag_diff(b.r, b.g, 0x00FF) ||
+                     __flag_diff(b.r, b.b, 0x00FF) ||
+                     __flag_diff(b.r, b.g, 0xFF00) ||
                      __flag_diff(b.r, b.b, 0xFF00)) << 6;
 #undef __flag_diff
 

--- a/cpp/lazperf/detail/field_rgb14.cpp
+++ b/cpp/lazperf/detail/field_rgb14.cpp
@@ -55,9 +55,9 @@ unsigned int color_diff_bits_1_4(const las::rgb14& color, const las::rgb14& last
         (flag_diff(a.g, b.g, 0xFF00) << 3) |
         (flag_diff(a.b, b.b, 0x00FF) << 4) |
         (flag_diff(a.b, b.b, 0xFF00) << 5) |
-        ((flag_diff(b.r, b.g, 0x00FF) |
-          flag_diff(b.r, b.b, 0x00FF) |
-          flag_diff(b.r, b.g, 0xFF00) |
+        ((flag_diff(b.r, b.g, 0x00FF) ||
+          flag_diff(b.r, b.b, 0x00FF) ||
+          flag_diff(b.r, b.g, 0xFF00) ||
           flag_diff(b.r, b.b, 0xFF00)) << 6);
     return r;
 }


### PR DESCRIPTION
clang 14 -Werror throws warning
```
  cpp/lazperf/detail/field_rgb14.cpp:58:11:
  error: use of bitwise '|' with boolean operands
  [-Werror,-Wbitwise-instead-of-logical]
```

more details see https://cdash.orfeo-toolbox.org/viewBuildError.php?buildid=95486

reason is operator `|` expects bitwise operand but gets boolean operand as per function definition `flag_diff` returns `bool`
https://github.com/hobu/laz-perf/blob/faede41102a65b8c83b21edbd120a000316611da/cpp/lazperf/detail/field_rgb14.cpp#L46

issue was detected downstream in qgis with ci pipeline on fedora 36 using clang 14
while working on https://github.com/qgis/QGIS/pull/47887